### PR TITLE
Better hourly aggregation that handles missing blips.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,6 +104,21 @@ to log some blinks.
 ** The minimum blip length in that interval, in milliseconds.
 ** The maximum blip length in that interval, in milliseconds.
 
+* __/labibus_blip/\<dev\>__
+
+  Long-polling of Labibus. The server waits for the next data point on Labibus
+  device \<dev\> to be received, then returns it as the pair [stamp,value].
+
+* __/labibus_last/\<dev\>/\<n\>__
+
+  Returns the Labibus data for device \<dev\> within the last \<n\>
+  milliseconds (At most 20000 points will be returned though).
+
+* __/labibus_since/\<dev\>/\<stamp\>__
+
+  Returns the Labibus data for the device \<dev\> since the given unix
+  millisecond time stamp. At most 20000 points will be returned.
+
 [JSON]: http://json.org
 
 License

--- a/README.markdown
+++ b/README.markdown
@@ -94,9 +94,15 @@ to log some blinks.
 
 * __/hourly/\<m\>/\<n\>__
 
-  Returns usage per hour (in blips, which is the same as watt-hours per
-  hour). The usage is returned in the interval `<m>` to `<n>`, in
+  Returns usage per hour.
+  The usage is returned in the interval `<m>` to `<n>`, in
   unix millisecond timestamps.
+  5 values are returned for each hour-interval:
+** The unix millisecond timestamp of the start of the hour-interval
+** The number of blips received during that hour-interval
+** The average usage during that hour, in watts.
+** The minimum blip length in that interval, in milliseconds.
+** The maximum blip length in that interval, in milliseconds.
 
 [JSON]: http://json.org
 

--- a/blip.lua
+++ b/blip.lua
@@ -118,6 +118,22 @@ local function add_json(res, values)
 	res:add(']')
 end
 
+local function add_json5(res, values)
+  res:add('[')
+
+  local n = #values
+  if n > 0 then
+    for i = 1, n-1 do
+      local point = values[i]
+      res:add('[%s,%s,%s,%s,%s],', point[1], point[2], point[3], point[4], point[5])
+    end
+    local point = values[n]
+    res:add('[%s,%s,%s,%s,%s]', point[1], point[2], point[3], point[4], point[5])
+  end
+
+  res:add(']')
+end
+
 local function add_data(res, values)
 	res:add('[')
 
@@ -165,7 +181,7 @@ assert(db:prepare('labibus_status',  'SELECT id, active, description, unit, poll
 assert(db:prepare('labibus_datahdr',  'SELECT id, active, description, unit, poll_interval FROM device_last_active_status WHERE id = $1'))
 assert(db:prepare('labibus_data',  'select stamp, value from device_log where id = $1 order by stamp desc limit $2'))
 assert(db:prepare('aggregate', 'SELECT $2*DIV(stamp - $1, $2) hour_stamp, COUNT(ms) FROM readings WHERE stamp >=$1 AND stamp < $1+$2*$3 GROUP BY hour_stamp ORDER BY hour_stamp'))
-assert(db:prepare('hourly', 'SELECT stamp, events FROM readings_hourly WHERE stamp >= $1 AND stamp <= $2 ORDER BY STAMP'))
+assert(db:prepare('hourly', 'SELECT stamp, events, wh, min_ms, max_ms FROM usage_hourly WHERE stamp >= $1 AND stamp <= $2 ORDER BY stamp'))
 
 OPTIONS('/last', apioptions)
 GET('/last', function(req, res)
@@ -203,7 +219,7 @@ GETM('^/hourly/(%d+)/(%d+)$', function(req, res, since, last)
     return
   end
   apiheaders(res.headers)
-  add_json(res, assert(db:run('hourly', since, last)))
+  add_json5(res, assert(db:run('hourly', since, last)))
 end)
 
 OPTIONSM('^/last/(%d+)$', apioptions)

--- a/labibus.html
+++ b/labibus.html
@@ -40,10 +40,15 @@
             devicelist = document.getElementById('devicelist'),
             deviceheader = document.getElementById('deviceheader'),
             timezoneOffset = (new Date()).getTimezoneOffset() * 60000,
+            currentDevice, currentDescription, currentUnit,
+            runNumber = 0,
             preparePoint,
+            updateText,
             fillGraph,
             fillGraphLong,
             fillDeviceList,
+            callHome,
+            onDataReceived,
             setDeviceHdr;
 
         preparePoint = function (point) {
@@ -55,10 +60,13 @@
             point[0] = stamp;
         };
 
+        updateText = function (stamp, val) {
+            text.textContent = (new Date(stamp)).toString() + ': ' +
+                val + ' ' + currentUnit;
+        }
+
         fillGraph = function (values) {
-            var time = new Date(values[0][0]);
-            text.textContent = "Last data point: " +
-                 time.toString() + ' - ' + values[0][1];
+            updateText(values[0][0], values[0][1]);
             for (i in values) {
                 preparePoint(values[i]);
             }
@@ -66,6 +74,7 @@
             data = values;
 
             $.plot(graph, [ data ], options);
+            callHome();
         };
 
         fillGraphLong = function (values) {
@@ -78,22 +87,53 @@
             $.plot(graphLong, [ dataLong ], options);
         };
 
+        callHome = function() {
+            var cb = onDataReceived(runNumber);
+            $.ajax({
+                url: '/labibus_blip/' + currentDevice,
+                method: 'GET',
+                dataType: 'json',
+                success: cb
+            });
+        };
+
+        onDataReceived = function(num) { return function (point) {
+            if (num != runNumber) { return null; }
+
+            var stamp = point[0], val = point[1];
+            updateText(stamp, val);
+
+            preparePoint(point);
+            data.push(point);
+
+            stamp = point[0] - 3600000; /* one hour */
+            while (data[0][0] < stamp) {
+               data.shift();
+            }
+
+            $.plot(graph, [ data ], options);
+            callHome();
+        } }
+
         setDeviceHdr = function (status) {
-            deviceheader.textContent = 'Device ' + status[0][0] + ': ' +
-                status[0][2] + ', in ' + status[0][3];
+            currentDevice = status[0][0];
+            currentDescription = status[0][2];
+            currentUnit = status[0][3];
+            deviceheader.textContent = 'Device ' + currentDevice + ': ' +
+                currentDescription + ', in ' + currentUnit;
             options.yaxis.tickFormatter = function (val, axis) {
-                return val.toFixed(axis.tickDecimals) + " " + status[0][3];
+                return val.toFixed(axis.tickDecimals) + " " + currentUnit;
             }
 
             $.ajax({
-                url: 'https://power.labitat.dk/labibus_data/' + status[0][0] + '/1000',
+                url: 'https://power.labitat.dk/labibus_last/' + currentDevice + '/3600000',
                 method: 'GET',
                 dataType: 'json',
                 success: fillGraph
             });
 
             $.ajax({
-                url: 'https://power.labitat.dk/labibus_data/' + status[0][0] + '/20000',
+                url: 'https://power.labitat.dk/labibus_last/' + currentDevice + '/86400000',
                 method: 'GET',
                 dataType: 'json',
                 success: fillGraphLong
@@ -101,6 +141,7 @@
         }
 
         showDevice = function (dev) {
+            runNumber++;
             $.ajax({
                 url: '/labibus_status/' + dev,
                 method: 'GET',

--- a/lastweek.html
+++ b/lastweek.html
@@ -40,9 +40,9 @@
             newValues = [ ];
             for (i = 0; i < values.length - 1; i++) {
                 newValues.push([values[i][0] - timezoneOffset,
-                                values[i][1]]);
+                                values[i][2]]);
                 newValues.push([values[i+1][0] - timezoneOffset,
-                                values[i][1]]);
+                                values[i][2]]);
             }
             data = newValues;
 


### PR DESCRIPTION
Use the sum of all blips to get the length of the period actually measured (in
case the blipserver might have been down for a few minutes), thus getting
more accurate estimate for partially measured periods.

And also record the min and max blip length in each period.